### PR TITLE
Fix buffer size for audio path

### DIFF
--- a/examples/IDF_RandomAudioPlayer/main/random_audio_player.c
+++ b/examples/IDF_RandomAudioPlayer/main/random_audio_player.c
@@ -90,8 +90,14 @@ static char* random_audio_file(void)
     for (int i = 0; i <= target; ++i) {
         entry = readdir(dir);
     }
-    char *path = malloc(64);
-    snprintf(path, 64, SD_MOUNT_POINT "/audio/%s", entry->d_name);
+    const char *prefix = SD_MOUNT_POINT "/audio/";
+    size_t needed = strlen(prefix) + strlen(entry->d_name) + 1;
+    char *path = malloc(needed);
+    if (!path) {
+        closedir(dir);
+        return NULL;
+    }
+    snprintf(path, needed, "%s%s", prefix, entry->d_name);
     closedir(dir);
     return path;
 }


### PR DESCRIPTION
## Summary
- calculate required buffer for file paths in IDF random audio player

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684728c64ba4832cb8ace607de8d905c