### PR TITLE
Add speech commands example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ The audio files must be placed inside `/sdcard/audio` on the SD card in standard
 A simple IDF example combining wake word detection with audio playback is available in `examples/IDF_WakeWordPlayer`.
 It uses the ESP-SR library to detect the built-in "Hi ESP" phrase via the onboard microphones and plays a random WAV file from the SD card when triggered.
 
-## Hotword Integration
+## Speech Commands Example
 
-The repository does not include voice recognition. If you want to start playback in response to a voice command, integrate a hotword detection library and call the playback functions when the hotword is detected. See [docs/HOTWORDS.md](docs/HOTWORDS.md) for guidance.
+`examples/IDF_SpeechCommands` showcases offline recognition of a small set of
+Chinese voice commands using the ESP-SR Multinet model. When a command is
+recognized its ID is printed to the serial console.
+
+## Hotword Integration
+For custom voice commands or different hotwords, integrate a third-party
+hotword detection library and call the playback functions when the hotword is
+detected. See [docs/HOTWORDS.md](docs/HOTWORDS.md) for guidance.

--- a/examples/IDF_SpeechCommands/CMakeLists.txt
+++ b/examples/IDF_SpeechCommands/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.5)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(idf_speech_commands)

--- a/examples/IDF_SpeechCommands/main/CMakeLists.txt
+++ b/examples/IDF_SpeechCommands/main/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "main.c" "speech_commands_action.c")

--- a/examples/IDF_SpeechCommands/main/idf_component.yml
+++ b/examples/IDF_SpeechCommands/main/idf_component.yml
@@ -1,0 +1,3 @@
+dependencies:
+  espressif/esp-sr: "^2.1.0"
+  espressif/esp_board: "^1.0.0"

--- a/examples/IDF_SpeechCommands/main/main.c
+++ b/examples/IDF_SpeechCommands/main/main.c
@@ -1,0 +1,106 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "esp_wn_iface.h"
+#include "esp_wn_models.h"
+#include "esp_afe_sr_iface.h"
+#include "esp_afe_sr_models.h"
+#include "esp_mn_iface.h"
+#include "esp_mn_models.h"
+#include "esp_board_init.h"
+#include "speech_commands_action.h"
+
+static esp_afe_sr_iface_t *afe_handle = NULL;
+static volatile int task_flag = 0;
+static int wakeup_flag = 0;
+static srmodel_list_t *models = NULL;
+
+static void feed_task(void *arg)
+{
+    esp_afe_sr_data_t *afe_data = arg;
+    int audio_chunksize = afe_handle->get_feed_chunksize(afe_data);
+    int nch = afe_handle->get_feed_channel_num(afe_data);
+    int feed_channel = esp_get_feed_channel();
+    int16_t *i2s_buff = malloc(audio_chunksize * sizeof(int16_t) * feed_channel);
+    while (task_flag) {
+        esp_get_feed_data(true, i2s_buff, audio_chunksize * sizeof(int16_t) * feed_channel);
+        afe_handle->feed(afe_data, i2s_buff);
+    }
+    free(i2s_buff);
+    vTaskDelete(NULL);
+}
+
+static void detect_task(void *arg)
+{
+    esp_afe_sr_data_t *afe_data = arg;
+    int afe_chunksize = afe_handle->get_fetch_chunksize(afe_data);
+    char *mn_name = esp_srmodel_filter(models, ESP_MN_PREFIX, ESP_MN_CHINESE);
+    printf("multinet: %s\n", mn_name);
+    esp_mn_iface_t *multinet = esp_mn_handle_from_name(mn_name);
+    model_iface_data_t *model_data = multinet->create(mn_name, 6000);
+    int mu_chunksize = multinet->get_samp_chunksize(model_data);
+    esp_mn_commands_update_from_sdkconfig(multinet, model_data);
+    multinet->print_active_speech_commands(model_data);
+    if (mu_chunksize != afe_chunksize) {
+        printf("Chunk size mismatch\n");
+    }
+
+    printf("------------detect start------------\n");
+    while (task_flag) {
+        afe_fetch_result_t* res = afe_handle->fetch(afe_data);
+        if (!res || res->ret_value == ESP_FAIL) {
+            printf("fetch error!\n");
+            break;
+        }
+
+        if (res->wakeup_state == WAKENET_DETECTED) {
+            wakeup_flag = 1;
+            wake_up_action();
+            multinet->clean(model_data);
+        } else if (res->raw_data_channels > 1 && res->wakeup_state == WAKENET_CHANNEL_VERIFIED) {
+            wakeup_flag = 1;
+            printf("Channel verified: %d\n", res->trigger_channel_id);
+            wake_up_action();
+            multinet->clean(model_data);
+        }
+
+        if (wakeup_flag == 1) {
+            esp_mn_state_t mn_state = multinet->detect(model_data, res->data);
+
+            if (mn_state == ESP_MN_STATE_DETECTED) {
+                esp_mn_results_t *mn_result = multinet->get_results(model_data);
+                if (mn_result->num > 0) {
+                    speech_commands_action(mn_result->command_id[0]);
+                }
+                printf("-----------listening-----------\n");
+            }
+
+            if (mn_state == ESP_MN_STATE_TIMEOUT) {
+                printf("timeout\n");
+                afe_handle->enable_wakenet(afe_data);
+                wakeup_flag = 0;
+                printf("\n-----------awaits to be waken up-----------\n");
+                continue;
+            }
+        }
+    }
+    multinet->destroy(model_data);
+    printf("detect exit\n");
+    vTaskDelete(NULL);
+}
+
+void app_main(void)
+{
+    models = esp_srmodel_init("model");
+    ESP_ERROR_CHECK(esp_board_init(16000, 1, 16));
+    afe_config_t *afe_config = afe_config_init(esp_get_input_format(), models, AFE_TYPE_SR, AFE_MODE_LOW_COST);
+    afe_handle = esp_afe_handle_from_config(afe_config);
+    esp_afe_sr_data_t *afe_data = afe_handle->create_from_config(afe_config);
+    afe_config_free(afe_config);
+
+    task_flag = 1;
+    xTaskCreatePinnedToCore(&detect_task, "detect", 8 * 1024, (void*)afe_data, 5, NULL, 1);
+    xTaskCreatePinnedToCore(&feed_task, "feed", 8 * 1024, (void*)afe_data, 5, NULL, 0);
+}

--- a/examples/IDF_SpeechCommands/main/speech_commands_action.c
+++ b/examples/IDF_SpeechCommands/main/speech_commands_action.c
@@ -1,0 +1,12 @@
+#include "speech_commands_action.h"
+#include <stdio.h>
+
+void wake_up_action(void)
+{
+    printf("Wake word detected\n");
+}
+
+void speech_commands_action(int command_id)
+{
+    printf("Command ID %d detected\n", command_id);
+}

--- a/examples/IDF_SpeechCommands/main/speech_commands_action.h
+++ b/examples/IDF_SpeechCommands/main/speech_commands_action.h
@@ -1,0 +1,7 @@
+#ifndef SPEECH_COMMANDS_ACTION_H
+#define SPEECH_COMMANDS_ACTION_H
+
+void wake_up_action(void);
+void speech_commands_action(int command_id);
+
+#endif // SPEECH_COMMANDS_ACTION_H


### PR DESCRIPTION
## Summary
- add an ESP-IDF speech command recognition example using ESP-SR
- document the new example in README

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472c380788832cb56ffd80592247af